### PR TITLE
[16.0][FIX] contract: missing dependency

### DIFF
--- a/contract/__manifest__.py
+++ b/contract/__manifest__.py
@@ -16,7 +16,7 @@
     "license": "AGPL-3",
     "author": "Tecnativa, ACSONE SA/NV, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/contract",
-    "depends": ["base", "account", "product", "portal"],
+    "depends": ["base", "account", "product", "portal", "analytic"],
     "development_status": "Production/Stable",
     "data": [
         "security/groups.xml",


### PR DESCRIPTION
[FIX] The `analytic_distribution` field of the analytic module is being used, so it gives an error when executed if it is not previously installed.